### PR TITLE
chore(migrations): maj fichiers migrations pour adapter la contrainte pgsql

### DIFF
--- a/database/migrations/2024_12_20_144229_create_bitcoins_table.php
+++ b/database/migrations/2024_12_20_144229_create_bitcoins_table.php
@@ -17,12 +17,12 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('symbol');
-            $table->decimal('price', 20, 8);
-            $table->decimal('market_cap', 20, 8)->nullable();
-            $table->decimal('volume', 20, 8)->nullable();
-            $table->string('change_1h', 10, 8)->nullable();
-            $table->string('change_24h', 10, 8)->nullable();
-            $table->string('change_7d', 10, 8)->nullable();
+            $table->decimal('price', 38, 8);
+            $table->decimal('market_cap', 38, 8)->nullable();
+            $table->decimal('volume', 38, 8)->nullable();
+            $table->string('change_1h')->nullable();
+            $table->string('change_24h')->nullable();
+            $table->string('change_7d')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_01_16_101848_create_ethereums_table.php
+++ b/database/migrations/2025_01_16_101848_create_ethereums_table.php
@@ -11,12 +11,12 @@ return new class extends Migration {
             $table->id();
             $table->string('name');
             $table->string('symbol');
-            $table->decimal('price', 20, 8);
-            $table->decimal('market_cap', 20, 8)->nullable();
-            $table->decimal('volume', 20, 8)->nullable();
-            $table->string('change_1h', 10, 8)->nullable();
-            $table->string('change_24h', 10, 8)->nullable();
-            $table->string('change_7d', 10, 8)->nullable();
+            $table->decimal('price', 38, 8);
+            $table->decimal('market_cap', 38, 8)->nullable();
+            $table->decimal('volume', 38, 8)->nullable();
+            $table->string('change_1h')->nullable();
+            $table->string('change_24h')->nullable();
+            $table->string('change_7d')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_01_16_102551_create_ripples_table.php
+++ b/database/migrations/2025_01_16_102551_create_ripples_table.php
@@ -11,12 +11,12 @@ return new class extends Migration {
             $table->id();
             $table->string('name');
             $table->string('symbol');
-            $table->decimal('price', 20, 8);
-            $table->decimal('market_cap', 20, 8)->nullable();
-            $table->decimal('volume', 20, 8)->nullable();
-            $table->string('change_1h', 10, 8)->nullable();
-            $table->string('change_24h', 10, 8)->nullable();
-            $table->string('change_7d', 10, 8)->nullable();
+            $table->decimal('price', 38, 8);
+            $table->decimal('market_cap', 38, 8)->nullable();
+            $table->decimal('volume', 38, 8)->nullable();
+            $table->string('change_1h')->nullable();
+            $table->string('change_24h')->nullable();
+            $table->string('change_7d')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_01_16_103415_create_cardanos_table.php
+++ b/database/migrations/2025_01_16_103415_create_cardanos_table.php
@@ -11,12 +11,13 @@ return new class extends Migration {
             $table->id();
             $table->string('name');
             $table->string('symbol');
-            $table->decimal('price', 20, 8);
-            $table->decimal('market_cap', 20, 8)->nullable();
-            $table->decimal('volume', 20, 8)->nullable();
-            $table->string('change_1h', 10, 8)->nullable();
-            $table->string('change_24h', 10, 8)->nullable();
-            $table->string('change_7d', 10, 8)->nullable();
+            $table->decimal('price', 38, 8);
+            $table->decimal('market_cap', 38, 8)->nullable();
+            $table->decimal('volume', 38, 8)->nullable();
+            $table->string('change_1h')->nullable();
+            $table->string('change_24h')->nullable();
+            $table->string('change_7d')->nullable();
+            $table->timestamps();
         });
     }
 

--- a/database/migrations/2025_01_16_104338_create_solanas_table.php
+++ b/database/migrations/2025_01_16_104338_create_solanas_table.php
@@ -11,12 +11,12 @@ return new class extends Migration {
             $table->id();
             $table->string('name');
             $table->string('symbol');
-            $table->decimal('price', 20, 8);
-            $table->decimal('market_cap', 20, 8)->nullable();
-            $table->decimal('volume', 20, 8)->nullable();
-            $table->string('change_1h', 10, 8)->nullable();
-            $table->string('change_24h', 10, 8)->nullable();
-            $table->string('change_7d', 10, 8)->nullable();
+            $table->decimal('price', 38, 8);
+            $table->decimal('market_cap', 38, 8)->nullable();
+            $table->decimal('volume', 38, 8)->nullable();
+            $table->string('change_1h')->nullable();
+            $table->string('change_24h')->nullable();
+            $table->string('change_7d')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
**Informations :**

- Rajout d'un champ `timestamp` pour la table `cardanos`
- MAJ de l'ensemble des **fichiers de migration des cryptos** pour p**ermettre d'augmenter la contrainte pgsql sur les nombres décimaux**